### PR TITLE
support `ForwardDiff@0.10`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Distributions = "0.25.119"
-ForwardDiff = "1"
+ForwardDiff = "0.10, 1"
 LowLevelParticleFilters = "3.19.1"
 ModelingToolkit = "10.0"
 MonteCarloMeasurements = "1.4.5"


### PR DESCRIPTION
Ensures broader compatibility with the ecosystem for now (some packages haven't upgraded to 1.0 yet and the differences are unlikely to be breaking in practice.