### PR TITLE
Add static keyword argument to control array types in d0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LowLevelParticleFiltersMTK"
 uuid = "6906b499-63f5-4dd8-acfd-28b0f8b24f7d"
 authors = ["Fredrik Bagge Carlson"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"


### PR DESCRIPTION
## Summary
- Adds a `static=true` keyword argument to `StateEstimationProblem` that controls whether to use static arrays (`SVector`/`SMatrix`) or regular arrays (`Vector`/`Matrix`) for the initial distribution `d0`
- Defaults to `static=true` for backward compatibility
- When `static=false`, uses regular arrays for both `x0` and `R` in the initial distribution
- Bumps version from 0.2.2 to 0.2.3

## Motivation
This provides flexibility for users who may need regular arrays for certain applications while maintaining the performance benefits of static arrays as the default behavior.

## Test plan
- [ ] Verify existing tests pass with default `static=true`
- [ ] Test with `static=false` to ensure regular arrays are used correctly
- [ ] Confirm backward compatibility (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)