### PR TITLE
Fix B2: propagate_distribution (UKF) honors kf.state_mean/state_cov

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -352,8 +352,8 @@ function propagate_distribution(f, kf::UnscentedKalmanFilter, x, args...; kwargs
     m,S = mean(x), cov(x)
     xs = LowLevelParticleFilters.sigmapoints(m, S, kf.weight_params; cholesky! = kf.cholesky!)
     ys = [f(x, args...; kwargs...) for x in xs]
-    my = LowLevelParticleFilters.mean_with_weights(weighted_mean, ys, kf.weight_params)
-    Sy = LowLevelParticleFilters.cov_with_weights(weighted_cov, ys, my, kf.weight_params)
+    my = LowLevelParticleFilters.mean_with_weights(kf.state_mean, ys, kf.weight_params)
+    Sy = LowLevelParticleFilters.cov_with_weights(kf.state_cov, ys, my, kf.weight_params)
     return SimpleMvNormal(my, Sy)
 end
 

--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -508,7 +508,12 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
     t = ModelingToolkit.get_iv(iosys)
     Afun  = Symbolics.build_function(A,  x_sym, inputs, ps, t; force_SA, expression)[1]
     Bfun = Symbolics.build_function(B, x_sym, inputs, ps, t; force_SA, expression)[1]
-    discABfun = Symbolics.build_function(Base.exp(Ts*Num.([A B; zeros(nu, nx+nu)])),  x_sym, inputs, ps, t; force_SA, expression)[1]
+    # Build a function that returns the augmented continuous-time matrix [A B; 0 0]
+    # numerically; the matrix exponential is then taken at runtime on the numeric matrix.
+    # (Calling Base.exp on a Matrix{Num} dispatches to LinearAlgebra's matrix exponential,
+    # which only supports Float/Complex element types.)
+    ABaugfun = Symbolics.build_function(Num.([A B; zeros(nu, nx+nu)]), x_sym, inputs, ps, t; force_SA, expression)[1]
+    discABfun = (x,u,p,t) -> Base.exp(Ts * ABaugfun(x,u,p,t))
 
     if parametricA
         if discretize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,6 +116,37 @@ plot!(solu, idxs=cmodel.y^2 + 0.1*sin(cmodel.u))
 end
 
 
+@testset "propagate_distribution uses kf.state_mean / kf.state_cov (UKF)" begin
+    # Build a UKF where state_mean / state_cov are sentinel wrappers around the
+    # defaults that record they were called. propagate_distribution must invoke
+    # the kf's own functions, not hard-coded weighted_mean/weighted_cov.
+    state_mean_called = Ref(0)
+    state_cov_called  = Ref(0)
+    function tagged_mean(xs, W)
+        state_mean_called[] += 1
+        LowLevelParticleFilters.weighted_mean(xs, W)
+    end
+    function tagged_cov(xs, m, W)
+        state_cov_called[] += 1
+        LowLevelParticleFilters.weighted_cov(xs, m, W)
+    end
+
+    prob_p = StateEstimationProblem(cmodel, inputs, outputs; disturbance_inputs, df, dg, discretization, Ts)
+    ukf_tagged = UnscentedKalmanFilter{false,false,true,false}(
+        prob_p.f, prob_p.g, prob_p.df.Σ, prob_p.dg.Σ, prob_p.d0;
+        prob_p.Ts, prob_p.nu, prob_p.ny, prob_p.nx, prob_p.p,
+        state_mean = tagged_mean, state_cov = tagged_cov,
+    )
+
+    f = x -> 2.0 .* x
+    d_in = SimpleMvNormal(SVector(0.5), SMatrix{1,1}(0.25))
+    propagate_distribution(f, ukf_tagged, d_in)
+
+    @test state_mean_called[] >= 1
+    @test state_cov_called[]  >= 1
+end
+
+
 @testset "linear" begin
     @info "Testing linear"
     include("test_linear.jl")


### PR DESCRIPTION
## Summary
- `propagate_distribution(f, kf::UnscentedKalmanFilter, ...)` previously hard-coded `weighted_mean` / `weighted_cov` for the sigma-point reduction, silently ignoring the filter's configured `state_mean` / `state_cov`. If the user constructed the UKF with custom reductions (e.g. for circular/manifold-valued states), the propagated distribution used the wrong mean and covariance.
- Forward through `kf.state_mean` and `kf.state_cov` instead.

## Test plan
- [x] New testset constructs a UKF with sentinel-wrapped `state_mean` / `state_cov`, runs `propagate_distribution`, and asserts both wrappers were invoked.
- [x] `Pkg.test()` passes locally.

## Dependencies
Stacked on #28 (`exp(::Matrix{Num})` fix) for tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)