### PR TITLE
Fix B3: read post-init parameters from initsol, not initprob

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -116,7 +116,9 @@ function StateEstimationProblem(model, inputs, outputs; disturbance_inputs, disc
     if init
         initprob = ModelingToolkit.InitializationProblem(iosys, 0.0, op)
         initsol = solve(initprob)
-        p = Tuple(initprob.ps[p] for p in ps) # Use tuple instead of heterogeneously typed array for better performance
+        # Read parameters from the solution, not the problem: initialization may solve
+        # for parameter values, in which case initprob.ps[p] returns the pre-solve guess.
+        p = Tuple(initsol.ps[p] for p in ps)
         x0 = SVector{nx}(initsol[x_sym])
     else
         prob = ModelingToolkit.ODEProblem(iosys, op, (0.0, Ts))
@@ -484,7 +486,9 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
     if init
         initprob = ModelingToolkit.InitializationProblem(iosys, 0.0, op)
         initsol = solve(initprob)
-        p = Tuple(initprob.ps[p] for p in ps) # Use tuple instead of heterogeneously typed array for better performance
+        # Read parameters from the solution, not the problem: initialization may solve
+        # for parameter values, in which case initprob.ps[p] returns the pre-solve guess.
+        p = Tuple(initsol.ps[p] for p in ps)
         x0 = SVector{nx}(initsol[x_sym])
     else
         x0 = SVector{nx}(ModelingToolkit.get_u0(iosys, op))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,38 @@ end
 end
 
 
+@testset "init=true exercises the InitializationProblem code path" begin
+    # Smoke test for the init=true branch: with a parametric model, verify the
+    # constructor runs, parameters are read from initsol, and the resulting
+    # filter can process a trajectory.
+    @component function ParamSys(; name)
+        @parameters a = 2.0
+        @variables begin
+            x(t) = 0.0
+            u(t) = 0.0
+            y(t)
+            w(t), [disturbance = true, input = true]
+        end
+        eqs = [D(x) ~ -a*x + u + w, y ~ x]
+        ODESystem(eqs, t; name)
+    end
+    @named ps_model = ParamSys()
+    cps = complete(ps_model)
+
+    prob_init = StateEstimationProblem(cps, [cps.u], [cps.y];
+        disturbance_inputs=[cps.w], df, dg, discretization, Ts,
+        pmap = Dict(cps.a => 3.5),
+        init = true)
+    # Single parameter `a` set via pmap, read back from initsol.ps[a]
+    @test prob_init.p == (3.5,)
+
+    # End-to-end: filter should run on the trajectory
+    ekf_init = get_filter(prob_init, ExtendedKalmanFilter)
+    fsol_init = forward_trajectory(ekf_init, u, y)
+    @test length(fsol_init.xt) == length(u)
+end
+
+
 @testset "linear" begin
     @info "Testing linear"
     include("test_linear.jl")


### PR DESCRIPTION
## Summary
- MTK's initialization can solve for parameter values (via guesses, constraint equations, etc.). The previous code read parameters as `initprob.ps[p]` — these are the pre-solve guesses, not the solved values stored in `initsol`.
- Read from `initsol.ps[p]` instead, in both `StateEstimationProblem` and `KalmanFilter` constructors.

## Test plan
- [x] Existing test suite passes (`Pkg.test()` green locally).
- ⚠️  No targeted regression test added: constructing an MTK model where initialization actually solves for a parameter is non-trivial; the fix is a careful no-op for cases where init does not modify parameters, and correct for cases where it does.

## Dependencies
Stacked on #28 (`exp(::Matrix{Num})` fix) for tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)