### PR TITLE
Fix B4: error on mixed Distribution/scalar x0map

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -97,16 +97,22 @@ function StateEstimationProblem(model, inputs, outputs; disturbance_inputs, disc
     # Handle initial distribution
     pmap = merge(Dict(disturbance_inputs .=> 0.0), Dict(pmap)) # Make sure disturbance inputs are initialized to zero if they are not explicitly provided in pmap
     x0map = collect(x0map)
-    if !isempty(x0map) && (x0map[1][2] isa Distribution)
-        stdmap = map(collect(x0map)) do (sym, dist)
-            sym => dist.σ
-        end |> Dict
-        x0map = map(collect(x0map)) do (sym, dist)
-            sym => dist.μ
+    if !isempty(x0map)
+        is_dist = map(p -> p[2] isa Distribution, x0map)
+        if any(is_dist) && !all(is_dist)
+            error("x0map must contain either only Distribution values or only scalar values, got a mix. Offending entries: $([p for (p, d) in zip(x0map, is_dist) if d != is_dist[1]])")
         end
-        dists = true
+        dists = all(is_dist)
     else
         dists = false
+    end
+    if dists
+        stdmap = map(x0map) do (sym, dist)
+            sym => dist.σ
+        end |> Dict
+        x0map = map(x0map) do (sym, dist)
+            sym => dist.μ
+        end
     end
 
     # Merge x0map and pmap into a single op mapping for InitializationProblem
@@ -465,16 +471,22 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
     # Handle initial distribution
     pmap = merge(Dict(all_inputs .=> 0.0), Dict(pmap)) # Make sure disturbance inputs are initialized to zero if they are not explicitly provided in pmap
     x0map = collect(x0map)
-    if !isempty(x0map) && (x0map[1][2] isa Distribution)
-        stdmap = map(collect(x0map)) do (sym, dist)
-            sym => dist.σ
-        end |> Dict
-        x0map = map(collect(x0map)) do (sym, dist)
-            sym => dist.μ
+    if !isempty(x0map)
+        is_dist = map(p -> p[2] isa Distribution, x0map)
+        if any(is_dist) && !all(is_dist)
+            error("x0map must contain either only Distribution values or only scalar values, got a mix. Offending entries: $([p for (p, d) in zip(x0map, is_dist) if d != is_dist[1]])")
         end
-        dists = true
+        dists = all(is_dist)
     else
         dists = false
+    end
+    if dists
+        stdmap = map(x0map) do (sym, dist)
+            sym => dist.σ
+        end |> Dict
+        x0map = map(x0map) do (sym, dist)
+            sym => dist.μ
+        end
     end
 
     # Merge x0map and pmap into a single op mapping for InitializationProblem

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,27 @@ end
 end
 
 
+@testset "x0map mixed Distribution/scalar errors" begin
+    using Distributions
+    # All Distribution -> OK (no error)
+    prob_dist = StateEstimationProblem(cmodel, inputs, outputs;
+        disturbance_inputs, df, dg, discretization, Ts,
+        x0map = [cmodel.x => Normal(0.0, 1.0)])
+    @test prob_dist isa StateEstimationProblem
+
+    # All scalar -> OK (no error)
+    prob_sc = StateEstimationProblem(cmodel, inputs, outputs;
+        disturbance_inputs, df, dg, discretization, Ts,
+        x0map = [cmodel.x => 0.0])
+    @test prob_sc isa StateEstimationProblem
+
+    # Mixed -> must error
+    bad = [cmodel.x => Normal(0.0, 1.0), cmodel.u => 0.5]
+    @test_throws ErrorException StateEstimationProblem(cmodel, inputs, outputs;
+        disturbance_inputs, df, dg, discretization, Ts, x0map = bad)
+end
+
+
 @testset "linear" begin
     @info "Testing linear"
     include("test_linear.jl")


### PR DESCRIPTION
## Summary
- The previous code inspected only `x0map[1][2] isa Distribution` to decide which branch to take. With a mixed `x0map` (some entries scalar, some `Distribution`), the code silently went down whichever branch the first element happened to select, producing an inconsistent initial state distribution. The docstring already required "all state variables must be provided values" when using Distributions, but it was not enforced.
- Reject mixed inputs with an informative error pointing at the offending entries.

## Test plan
- [x] New testset: all-Distribution OK, all-scalar OK, mixed throws `ErrorException`.
- [x] `Pkg.test()` passes locally.

## Dependencies
Stacked on #28 (`exp(::Matrix{Num})` fix) for tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)