### PR TITLE
Fix B5: build scale_x from x_sym, not unknowns(iosys)

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -144,7 +144,9 @@ function StateEstimationProblem(model, inputs, outputs; disturbance_inputs, disc
     end
 
     if xscalemap !== nothing
-        scale_x = map(unknowns(iosys)) do sym
+        # Use x_sym (the order generate_control_function and the dynamics function use),
+        # not unknowns(iosys), since the two may disagree.
+        scale_x = map(x_sym) do sym
             abs(get(xscalemap, sym, 1.0))
         end
         f_disc = discretization(f_cont, Ts, x_inds, a_inds, nu, scale_x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,21 @@ end
     @test out_override.μ[1] ≈ 10.0
 end
 
+@testset "xscalemap aligned with x_sym" begin
+    captured_scale = Ref{Vector{Float64}}()
+    custom_disc = function (f, Ts, x_inds, a_inds, nu, scale_x)
+        captured_scale[] = collect(scale_x)
+        f
+    end
+    prob_xs = StateEstimationProblem(cmodel, inputs, outputs;
+        disturbance_inputs, df, dg, discretization=custom_disc, Ts,
+        xscalemap = Dict(cmodel.x => 7.0))
+    # prob_xs.state is x_sym; scale_x must be indexed in the same order.
+    i = findfirst(isequal(cmodel.x), prob_xs.state)
+    @test i !== nothing
+    @test captured_scale[][i] == 7.0
+end
+
 
 @testset "linear" begin
     @info "Testing linear"


### PR DESCRIPTION
## Summary
- `scale_x` was built by iterating `unknowns(iosys)`, but every downstream consumer (`x_inds`, `a_inds`, the dynamics function, the initial state `x0`) is aligned with `x_sym` returned by `generate_control_function`. The two orderings are not guaranteed to match — when they diverge, every state gets scaled by the wrong factor with no warning.
- Iterate `x_sym` instead.

## Test plan
- [x] New testset uses a custom `discretization` to capture `scale_x` and asserts the captured value at the index of `cmodel.x` matches the value passed in the `xscalemap`.
- [x] `Pkg.test()` passes locally.

## Dependencies
Stacked on #28 (`exp(::Matrix{Num})` fix) for tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)