### PR TITLE
Fix B6: EstimatedOutput(kf,...) defaults t (and p) from the passed kf

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -246,10 +246,13 @@ struct EstimatedOutput{KF, P, G}
 end
 
 (gg::EstimatedOutput)(x::AbstractVector, u, p=gg.kf.p, t=gg.kf.t) = gg.g(x, u, p, t)
-function (gg::EstimatedOutput)(kf::AbstractKalmanFilter, u, args...; kwargs...)
+function (gg::EstimatedOutput)(kf::AbstractKalmanFilter, u,
+        p = LowLevelParticleFilters.parameters(kf),
+        t = LowLevelParticleFilters.index(kf) * kf.Ts;
+        kwargs...)
     x = kf.x
     R = kf.R
-    gg(SimpleMvNormal(x,R),u,args...)
+    gg(SimpleMvNormal(x,R), u, p, t; kwargs...)
 end
 
 function (gg::EstimatedOutput)(xR::SimpleMvNormal, u, p = gg.kf.p, t = gg.kf.t, args...; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,32 @@ end
 end
 
 
+@testset "EstimatedOutput(kf,...) defaults t from passed kf" begin
+    # Build a fresh prob/EKF and advance the filter so its index > 0
+    prob_t = StateEstimationProblem(cmodel, inputs, outputs;
+        disturbance_inputs, df, dg, discretization, Ts)
+    ekf_t = get_filter(prob_t, ExtendedKalmanFilter)
+    u0 = [0.0]
+    y0 = [0.0]
+    for _ = 1:3
+        LowLevelParticleFilters.predict!(ekf_t, u0)
+        LowLevelParticleFilters.correct!(ekf_t, u0, y0)
+    end
+    @assert ekf_t.t > 0
+
+    # Output expression that depends on time: 2*t (using the global iv)
+    eo = EstimatedOutput(ekf_t, prob_t, 2 * t)
+    # default t should be LowLevelParticleFilters.index(kf)*kf.Ts
+    expected_t = 2 * (LowLevelParticleFilters.index(ekf_t) * ekf_t.Ts)
+    out = eo(ekf_t, u0)
+    @test out.μ[1] ≈ expected_t
+
+    # explicit t override
+    out_override = eo(ekf_t, u0, ekf_t.p, 5.0)
+    @test out_override.μ[1] ≈ 10.0
+end
+
+
 @testset "linear" begin
     @info "Testing linear"
     include("test_linear.jl")


### PR DESCRIPTION
## Summary
- The `(gg::EstimatedOutput)(kf, u, args...)` method forwarded `args...` to the `SimpleMvNormal` dispatch, which then defaulted `p` and `t` from `gg.kf` — the filter captured at `EstimatedOutput` construction, not the one passed in. So calling `g(kf2, u)` with a different filter (or the same filter at a later time) silently used stale `p`/`t`.
- Default `p = LowLevelParticleFilters.parameters(kf)` and `t = LowLevelParticleFilters.index(kf) * kf.Ts` in the signature; both remain overridable by the caller.

## Test plan
- [x] New testset advances a filter for 3 steps, constructs `EstimatedOutput` for the time expression `2*t`, and asserts `out.μ[1] ≈ 2*(index(kf)*kf.Ts)` (default) and `out.μ[1] ≈ 10.0` (explicit override to 5).
- [x] `Pkg.test()` passes locally.

## Dependencies
Stacked on #28 (`exp(::Matrix{Num})` fix) for tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)