### PR TITLE
Fix B1: apply ZOH discretization to non-parametric A/B

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -515,6 +515,14 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
     ABaugfun = Symbolics.build_function(Num.([A B; zeros(nu, nx+nu)]), x_sym, inputs, ps, t; force_SA, expression)[1]
     discABfun = (x,u,p,t) -> Base.exp(Ts * ABaugfun(x,u,p,t))
 
+    # When discretize=true and A/B is non-parametric, evaluate discABfun once at the
+    # nominal point to obtain numeric discrete-time matrices. Without this, the
+    # non-parametric branch would feed the continuous-time A/B to the discrete KalmanFilter.
+    if discretize && (!parametricA || !parametricB)
+        u0_disc = static ? zero(SVector{nu, Float64}) : zeros(nu)
+        ABd0 = discABfun(x0, u0_disc, p, 0.0)
+    end
+
     if parametricA
         if discretize
             A = function (x,u,p,t)
@@ -525,7 +533,11 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
             A = Afun
         end
     else
-        A = really_unwrap.(A)
+        if discretize
+            A = ABd0[1:nx, 1:nx]
+        else
+            A = really_unwrap.(A)
+        end
     end
     if parametricB
         if discretize
@@ -537,7 +549,11 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
             B = Bfun
         end
     else
-        B = really_unwrap.(B)
+        if discretize
+            B = ABd0[1:nx, nx+1:end]
+        else
+            B = really_unwrap.(B)
+        end
     end
     if parametricC
         Cfun = Symbolics.build_function(C, x_sym, inputs, ps, t; force_SA, expression)[1]

--- a/test/test_linear.jl
+++ b/test/test_linear.jl
@@ -72,6 +72,42 @@ for parametricA = (true, ),
     end
 end
 
+@testset "discretization with non-parametric A/B" begin
+    # Regression test: when parametricA=parametricB=false and discretize=true,
+    # the filter's A and B must be the discretized (ZOH) matrices, not the
+    # continuous-time ones. Uses a parameter-free model so that A is constant.
+    @component function ConstSys(; name)
+        @variables begin
+            x(t) = 0
+            u(t) = 0
+            y(t)
+            w(t), [disturbance = true, input = true]
+        end
+        equations = [
+            D(x) ~ -x + u + w
+            y ~ x
+        ]
+        return ODESystem(equations, t; name)
+    end
+    @named cm2 = ConstSys()
+    cm2c = complete(cm2)
+    in2 = [cm2c.u]; out2 = [cm2c.y]; din2 = [cm2c.w]
+
+    kf_param, = KalmanFilter(cm2c, in2, out2; disturbance_inputs=din2, R1, R2, Ts,
+        parametricA=true, parametricB=true, discretize=true)
+    kf_const, = KalmanFilter(cm2c, in2, out2; disturbance_inputs=din2, R1, R2, Ts,
+        parametricA=false, parametricB=false, discretize=true)
+
+    xz = zero(SVector{1, Float64})
+    uz = zero(SVector{1, Float64})
+    Ad_param = kf_param.A(xz, uz, kf_param.p, 0.0)
+    Bd_param = kf_param.B(xz, uz, kf_param.p, 0.0)
+
+    @test kf_const.A ≈ Ad_param
+    @test kf_const.B ≈ Bd_param
+    # Continuous A = -1; the discretized A must equal exp(-Ts), not -1.
+    @test kf_const.A[1,1] ≈ exp(-Ts)
+end
 
 
 using Plots


### PR DESCRIPTION
## Summary
- When `parametricA=false` or `parametricB=false` with `discretize=true`, `KalmanFilter` previously fed the **continuous-time** `A`/`B` to the discrete `KalmanFilter` constructor, silently producing wrong predictions. The bug was hidden because the existing test loop fixed `parametricA = (true,)`.
- Evaluate `discABfun` once at the nominal `(x0, 0, p, 0.0)` and split the result to recover the numeric discrete-time `Ad`/`Bd` in the non-parametric branches.

(Reopen of #29 after rebasing onto main.)

## Test plan
- [x] New `@testset` in `test/test_linear.jl` constructs a parameter-free model and asserts `kf_const.A ≈ kf_param.A(...)` and `kf_const.A[1,1] ≈ exp(-Ts)` (vs. the buggy `-1`).
- [x] `Pkg.test()` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)