### PR TITLE
Fix B8: build discABfun only when discretize=true

### DIFF
--- a/src/LowLevelParticleFiltersMTK.jl
+++ b/src/LowLevelParticleFiltersMTK.jl
@@ -512,8 +512,12 @@ function LowLevelParticleFilters.KalmanFilter(model::System, inputs, outputs; di
     # numerically; the matrix exponential is then taken at runtime on the numeric matrix.
     # (Calling Base.exp on a Matrix{Num} dispatches to LinearAlgebra's matrix exponential,
     # which only supports Float/Complex element types.)
-    ABaugfun = Symbolics.build_function(Num.([A B; zeros(nu, nx+nu)]), x_sym, inputs, ps, t; force_SA, expression)[1]
-    discABfun = (x,u,p,t) -> Base.exp(Ts * ABaugfun(x,u,p,t))
+    # Only build this when discretization is requested -- the symbolic build is wasted
+    # work otherwise and can be slow for non-trivial systems.
+    if discretize
+        ABaugfun = Symbolics.build_function(Num.([A B; zeros(nu, nx+nu)]), x_sym, inputs, ps, t; force_SA, expression)[1]
+        discABfun = (x,u,p,t) -> Base.exp(Ts * ABaugfun(x,u,p,t))
+    end
 
     if parametricA
         if discretize


### PR DESCRIPTION
## Summary
- The symbolic augmented-matrix exponential build (`Symbolics.build_function` over the deferred `exp(Ts*[A B; 0 0])`) was executed unconditionally on every `KalmanFilter` constructor call, including `discretize=false`. For non-trivial systems the symbolic build is the dominant cost of constructor.
- Guard it behind the `discretize` flag.

## Test plan
- [x] `Pkg.test()` passes locally — the test suite exercises both `discretize=true` and `discretize=false` paths.
- [x] Behavior unchanged when `discretize=true` (`discABfun` is still built and used identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)